### PR TITLE
feat(ui): localize booth ui copy to Korean

### DIFF
--- a/apps/mobile/src/pages/booth-home/ui/BoothHomeScreen.test.tsx
+++ b/apps/mobile/src/pages/booth-home/ui/BoothHomeScreen.test.tsx
@@ -73,7 +73,7 @@ describe('BoothHomeScreen offline integration', () => {
 
     expect(
       renderer.root.findByProps({
-        children: 'No internet connection. Some booth actions are unavailable.',
+        children: '인터넷 연결이 없습니다. 일부 부스 기능을 사용할 수 없어요.',
       }),
     ).toBeDefined();
 
@@ -107,12 +107,12 @@ describe('BoothHomeScreen offline integration', () => {
     const renderer = render(<BoothHomeScreen />);
 
     expect(renderer.root.findByProps({ children: 'Phos MVP' })).toBeDefined();
-    expect(renderer.root.findByProps({ children: 'Frame presets' })).toBeDefined();
-    expect(renderer.root.findByProps({ children: 'Session contract' })).toBeDefined();
+    expect(renderer.root.findByProps({ children: '프레임 프리셋' })).toBeDefined();
+    expect(renderer.root.findByProps({ children: '세션 계약' })).toBeDefined();
 
     expect(() => {
       renderer.root.findByProps({
-        children: 'No internet connection. Some booth actions are unavailable.',
+        children: '인터넷 연결이 없습니다. 일부 부스 기능을 사용할 수 없어요.',
       });
     }).toThrow();
   });

--- a/apps/mobile/src/pages/booth-home/ui/BoothHomeScreen.tsx
+++ b/apps/mobile/src/pages/booth-home/ui/BoothHomeScreen.tsx
@@ -17,10 +17,10 @@ export function BoothHomeScreen() {
 
       <View style={styles.hero}>
         <Text style={styles.kicker}>Phos MVP</Text>
-        <Text style={styles.title}>Capture the booth flow before feature work starts.</Text>
+        <Text style={styles.title}>기능 개발 전에 포토부스 흐름을 먼저 점검하세요.</Text>
         <Text style={styles.description}>
-          The mobile app is structured with FSD layers and already shares the frame/session
-          contracts that the Nest API exposes.
+          모바일 앱은 FSD 레이어 구조로 구성되어 있고, Nest API가 제공하는 프레임/세션 계약을 이미
+          공유합니다.
         </Text>
       </View>
 

--- a/apps/mobile/src/shared/ui/OfflineBanner.tsx
+++ b/apps/mobile/src/shared/ui/OfflineBanner.tsx
@@ -10,7 +10,7 @@ export interface OfflineBannerProps {
 
 export function OfflineBanner({
   isOffline,
-  message = 'No internet connection. Some booth actions are unavailable.',
+  message = '인터넷 연결이 없습니다. 일부 부스 기능을 사용할 수 없어요.',
   onRetry,
 }: OfflineBannerProps) {
   if (!isOffline) {
@@ -22,7 +22,7 @@ export function OfflineBanner({
       <Text style={styles.message}>{message}</Text>
       {onRetry ? (
         <Pressable accessibilityRole="button" onPress={onRetry} style={styles.retryButton}>
-          <Text style={styles.retryText}>Retry</Text>
+          <Text style={styles.retryText}>재시도</Text>
         </Pressable>
       ) : null}
     </View>

--- a/apps/mobile/src/widgets/experience-overview/ui/ExperienceOverview.tsx
+++ b/apps/mobile/src/widgets/experience-overview/ui/ExperienceOverview.tsx
@@ -10,17 +10,17 @@ interface ExperienceOverviewProps {
 
 export function ExperienceOverview({ frames }: ExperienceOverviewProps) {
   return (
-    <InfoCard title="Frame presets" subtitle="Shared contract data from @phos/shared">
+    <InfoCard title="프레임 프리셋" subtitle="@phos/shared의 공통 계약 데이터">
       <View style={styles.list}>
         {frames.map((frame) => (
           <View key={frame.frameId} style={styles.item}>
             <View>
               <Text style={styles.itemTitle}>{frame.title}</Text>
               <Text style={styles.itemMeta}>
-                {frame.layoutType} · {frame.slotCount} shots
+                {frame.layoutType} · {frame.slotCount}컷
               </Text>
             </View>
-            <Text style={styles.itemState}>{frame.isActive ? 'Ready' : 'Paused'}</Text>
+            <Text style={styles.itemState}>{frame.isActive ? '사용 가능' : '일시 중지'}</Text>
           </View>
         ))}
       </View>

--- a/apps/mobile/src/widgets/session-readiness/ui/SessionReadiness.tsx
+++ b/apps/mobile/src/widgets/session-readiness/ui/SessionReadiness.tsx
@@ -35,13 +35,13 @@ const validatedPreview: MobileSessionSummary | null = validationResult.success
 
 export function SessionReadiness() {
   return (
-    <InfoCard title="Session contract" subtitle="Valibot validates API-shaped payloads on mobile">
+    <InfoCard title="세션 계약" subtitle="모바일에서 Valibot으로 API 형태 페이로드를 검증합니다">
       <View style={styles.row}>
         <View>
-          <Text style={styles.label}>Preview payload</Text>
-          <Text style={styles.value}>{validatedPreview ? 'Validated' : 'Invalid'}</Text>
+          <Text style={styles.label}>미리보기 페이로드</Text>
+          <Text style={styles.value}>{validatedPreview ? '검증 완료' : '검증 실패'}</Text>
         </View>
-        <Text style={styles.badge}>{validatedPreview ? 'valibot ok' : 'needs review'}</Text>
+        <Text style={styles.badge}>{validatedPreview ? '검증 정상' : '검토 필요'}</Text>
       </View>
     </InfoCard>
   );


### PR DESCRIPTION
## Summary
- Localize BoothHome hero copy, offline banner message/action, and overview/session widget labels to Korean.
- Update `BoothHomeScreen` UI test assertions to match localized strings while preserving existing behavior checks.
- Keep layout/styling structure unchanged and only adjust user-facing copy.

## Changed files
- `apps/mobile/src/pages/booth-home/ui/BoothHomeScreen.tsx`
- `apps/mobile/src/shared/ui/OfflineBanner.tsx`
- `apps/mobile/src/widgets/experience-overview/ui/ExperienceOverview.tsx`
- `apps/mobile/src/widgets/session-readiness/ui/SessionReadiness.tsx`
- `apps/mobile/src/pages/booth-home/ui/BoothHomeScreen.test.tsx`

## Validation
- [x] `pnpm --filter @phos/shared build`
- [x] `pnpm --filter mobile typecheck`
- [x] `pnpm --filter mobile test`
- [x] `pnpm build`